### PR TITLE
Don't compile in rdoc and ri. Default is also newest brakeman.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val installAll =
   s"""apk update && apk add bash curl &&
      |apk add --update ruby ruby-bundler ruby-dev &&
      |rm /var/cache/apk/* &&
-     |gem install brakeman""".stripMargin.replaceAll(System.lineSeparator(), " ")
+     |gem install brakeman --no-rdoc --no-ri""".stripMargin.replaceAll(System.lineSeparator(), " ")
 
 mappings in Universal <++= (resourceDirectory in Compile) map { (resourceDir: File) =>
   val src = resourceDir / "docs"

--- a/src/main/scala/codacy/brakeman/Brakeman.scala
+++ b/src/main/scala/codacy/brakeman/Brakeman.scala
@@ -131,6 +131,11 @@ object Brakeman extends Tool {
       case 86 => "ForgerySetting"
       case 87 => "JSONEncoding"
       case 88 => "XMLDoS"
+      case 89 => "SafeBufferManipulation"
+      case 90 => "SendFile"
+      case 91 => "SessionManipulation"
+      case 92 => "WeakHash"
+      case 93 => "CheckModelAttributes"
       case _ => "UnknowError"
     }
   }
@@ -202,7 +207,7 @@ object Brakeman extends Tool {
         Seq("-t", patternsIds.mkString(","))
     }
 
-    Seq("brakeman", "-f", "json") ++ patternsToTest ++ Seq(path.toString)
+    Seq("brakeman", "-A", "-f", "json") ++ patternsToTest ++ Seq(path.toString)
   }
 }
 


### PR DESCRIPTION
The newest module version is used by default, we might want to change this. Additionally run the extended check suite which picks up quite a few other vulnerability types.
